### PR TITLE
Check if there is a match in adjustPosition

### DIFF
--- a/lib/suggestion-portal.js
+++ b/lib/suggestion-portal.js
@@ -118,13 +118,14 @@ class SuggestionPortal extends React.Component {
   adjustPosition = () => {
     const { menu } = this.state
     if (!menu) return
-
-    if (this.matchCapture() === undefined) {
+    
+    const match = this.matchCapture();
+    if (match === undefined) {
       menu.removeAttribute('style')
       return
     }
 
-    if (this.matchTrigger()) {
+    if (this.matchTrigger() || match) {
       const rect = position()
       menu.style.display = 'block'
       menu.style.opacity = 1


### PR DESCRIPTION
... since else, as soon as current word doesn't exactly match trigger (`@`), the portal will disappear.