### PR TITLE
Add support for remote suggestions via promises.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ function SuggestionsPlugin(opts) {
         }
 
         // Handle enter
-        if (callback.onEnter) {
+        if (callback.onEnter && callback.suggestion !== undefined) {
           return callback.onEnter(callback.suggestion)
         }
       } else {

--- a/lib/suggestion-portal.js
+++ b/lib/suggestion-portal.js
@@ -12,7 +12,9 @@ import {
 
 class SuggestionPortal extends React.Component {
 
-  state = {}
+  state = {
+    filteredSuggestions: []
+  }
 
   componentDidMount = () => {
     this.adjustPosition()
@@ -30,31 +32,63 @@ class SuggestionPortal extends React.Component {
     props.callback.readOnly = false
 
     this.selectedIndex = 0
-    props.callback.suggestion = props.suggestions[this.selectedIndex]
+    if (typeof props.suggestions === 'function') {
+      props.callback.suggestion = undefined
+    } else {
+      this.state.filteredSuggestions = props.suggestions.slice(0, props.resultSize ? props.resultSize : RESULT_SIZE)
+      props.callback.suggestion = this.state.filteredSuggestions[this.selectedIndex]
+    }
   }
 
   onOpen = (portal) => {
     this.setState({ menu: portal.firstChild })
   }
 
+  setCallbackSuggestion = () => {
+    if (this.state.filteredSuggestions.length) {
+      this.props.callback.suggestion = this.state.filteredSuggestions[this.selectedIndex]
+    } else {
+      this.props.callback.suggestion = undefined
+    }
+  }
+
+  setFilteredSuggestions = (filteredSuggestions) => {
+    this.setState({
+      filteredSuggestions
+    })
+    this.setCallbackSuggestion()
+  }
+
   onKeyDown = (keyCode) => {
-    const filteredSuggestions = this.filteredSuggestions()
+    const { filteredSuggestions } = this.state
 
     if (keyCode === DOWN_ARROW_KEY) {
       if (this.selectedIndex + 1 === filteredSuggestions.length) {
         this.selectedIndex = -1
       }
       this.selectedIndex += 1
+      this.setCallbackSuggestion()
+      this.forceUpdate()
     } else if (keyCode === UP_ARROW_KEY) {
       if (this.selectedIndex === 0) {
         this.selectedIndex = filteredSuggestions.length
       }
       this.selectedIndex -= 1
+      this.setCallbackSuggestion()
+      this.forceUpdate()
     } else {
       this.selectedIndex = 0
+      const newFilteredSuggestions = this.getFilteredSuggestions()
+      if (typeof newFilteredSuggestions.then === 'function') {
+        newFilteredSuggestions.then(newFilteredSuggestions => {
+          this.setFilteredSuggestions(newFilteredSuggestions)
+        }).catch(() => {
+          this.setFilteredSuggestions([])
+        })
+      } else {
+        this.setFilteredSuggestions(newFilteredSuggestions)
+      }
     }
-
-    this.forceUpdate()
   }
 
   matchTrigger = () => {
@@ -99,7 +133,7 @@ class SuggestionPortal extends React.Component {
     return undefined
   }
 
-  filteredSuggestions = () => {
+  getFilteredSuggestions = () => {
     const { suggestions, state, capture, resultSize } = this.props
 
     if (!state.selection.anchorKey) return []
@@ -110,15 +144,19 @@ class SuggestionPortal extends React.Component {
 
     const text = this.getMatchText(currentWord, capture)
 
-    return suggestions
-      .filter(suggestion => suggestion.key.toLowerCase().indexOf(text) != -1)
-      .slice(0, resultSize ? resultSize : RESULT_SIZE)
+    if (typeof suggestions === 'function') {
+      return suggestions(text)
+    } else {
+      return suggestions
+        .filter(suggestion => suggestion.key.toLowerCase().indexOf(text) != -1)
+        .slice(0, resultSize ? resultSize : RESULT_SIZE)
+    }
   }
 
   adjustPosition = () => {
     const { menu } = this.state
     if (!menu) return
-    
+
     const match = this.matchCapture();
     if (match === undefined) {
       menu.removeAttribute('style')
@@ -150,14 +188,13 @@ class SuggestionPortal extends React.Component {
   }
 
   render = () => {
-    const suggestions = this.filteredSuggestions()
-    this.props.callback.suggestion = suggestions[this.selectedIndex]
+    const { filteredSuggestions } = this.state
 
     return (
       <Portal isOpened onOpen={this.onOpen}>
         <div className="suggestion-portal">
           <ul>
-            {suggestions.map((suggestion, index) =>
+            {filteredSuggestions.map((suggestion, index) =>
               <SuggestionItem
                 key={suggestion.key}
                 index={index}


### PR DESCRIPTION
This PR adds support for remotely fetched suggestions by extending the `suggestions` prop  to accept a function that returns a promise (as suggested in the [Issue 14](https://github.com/oozou/slate-suggestions/issues/14) discussion). 

Unlike in that discussion, this PR does not change the `suggestions` prop to _require_ a function or remove the `capture` prop since this change would be breaking and can easily be added afterwards. I like the idea and it would be easy to add after this PR but figured it should be done at the maintainers discretion.