### PR TITLE
Multiword search support

### DIFF
--- a/lib/current-word.js
+++ b/lib/current-word.js
@@ -1,12 +1,6 @@
-function getCurrentWord(text, index, initialIndex) {
-  if (text[index] === " " || text[index] === undefined) return ""
-  if (index < initialIndex) {
-    return getCurrentWord(text, index - 1, initialIndex) + text[index]
-  }
-  if (index > initialIndex) {
-    return text[index] + getCurrentWord(text, index + 1, initialIndex)
-  }
-  return getCurrentWord(text, index - 1, initialIndex) + text[index] + getCurrentWord(text, index + 1, initialIndex)
+function getCurrentWord(text, index, trigger) {
+  const startIndex = text.lastIndexOf(trigger, index + 1)
+  return text.substring(startIndex, index + 1)
 }
 
 export default getCurrentWord

--- a/lib/suggestion-portal.js
+++ b/lib/suggestion-portal.js
@@ -126,7 +126,7 @@ class SuggestionPortal extends React.Component {
   getMatchText = (text, trigger) => {
     const matchArr = text.match(trigger)
 
-    if (matchArr) {
+    if (matchArr && matchArr[0].length === text.length) {
       return matchArr[1].toLowerCase()
     }
 

--- a/lib/suggestion-portal.js
+++ b/lib/suggestion-portal.js
@@ -110,13 +110,13 @@ class SuggestionPortal extends React.Component {
   }
 
   matchCapture = () => {
-    const { state, capture } = this.props
+    const { state, capture, trigger } = this.props
 
     if (!state.selection.anchorKey) return ''
 
     const { anchorText, anchorOffset } = state
 
-    const currentWord = getCurrentWord(anchorText.text, anchorOffset - 1, anchorOffset - 1)
+    const currentWord = getCurrentWord(anchorText.text, anchorOffset - 1, trigger)
 
     const text = this.getMatchText(currentWord, capture)
 
@@ -134,13 +134,13 @@ class SuggestionPortal extends React.Component {
   }
 
   getFilteredSuggestions = () => {
-    const { suggestions, state, capture, resultSize } = this.props
+    const { suggestions, state, capture, resultSize, trigger } = this.props
 
     if (!state.selection.anchorKey) return []
 
     const { anchorText, anchorOffset } = state
 
-    const currentWord = getCurrentWord(anchorText.text, anchorOffset - 1, anchorOffset - 1)
+    const currentWord = getCurrentWord(anchorText.text, anchorOffset - 1, trigger)
 
     const text = this.getMatchText(currentWord, capture)
 
@@ -157,7 +157,7 @@ class SuggestionPortal extends React.Component {
     const { menu } = this.state
     if (!menu) return
 
-    const match = this.matchCapture();
+    const match = this.matchCapture()
     if (match === undefined) {
       menu.removeAttribute('style')
       return


### PR DESCRIPTION
This PR adds support for multiword searches. With it, it's possible to specify capture regexs like the following: `/#(.*)/`. This is useful if your tags can contain multiple words (e.g. first + last name).

Capture regexes that do not match white spaces (e.g. `/#([\w]*)/`) should work as before.